### PR TITLE
Update buff comparison

### DIFF
--- a/app/Http/Controllers/DMarketController.php
+++ b/app/Http/Controllers/DMarketController.php
@@ -52,37 +52,68 @@ class DMarketController extends Controller
 
         $result = [];
 
-        foreach ($targets['Items'] ?? [] as $target) {
-            $title = $target['Title'] ?? '';
-            $floatPartValue = $this->getAttr($target, 'floatPartValue');
-            $phase = $this->getAttr($target, 'phase');
+        if (!empty($targets['Items'])) {
+            foreach ($targets['Items'] as $target) {
+                $title = $target['Title'] ?? '';
+                $floatPartValue = $this->getAttr($target, 'floatPartValue');
+                $phase = $this->getAttr($target, 'phase');
 
-            $watchItem = UserWatchlistItem::where('title', $title)->first();
-            if (!$watchItem || !$watchItem->item_id) {
-                continue;
+                $watchItem = UserWatchlistItem::where('title', $title)->first();
+                if (!$watchItem || !$watchItem->item_id) {
+                    continue;
+                }
+
+                $range = $this->getPaintwearRange($floatPartValue);
+                $buffData = $buff->getSellOrders($watchItem->item_id, $range['min'], $range['max']);
+
+                $orders = $buffData['data']['items'] ?? [];
+                if ($phase) {
+                    $orders = array_values(array_filter($orders, fn ($o) => ($o['asset_info']['info']['phase_data']['name'] ?? null) === $phase));
+                }
+
+                if ($orders) {
+                    usort($orders, fn ($a, $b) => floatval($a['price']) <=> floatval($b['price']));
+                    $buffPrice = $orders[0]['price'];
+                } else {
+                    $buffPrice = null;
+                }
+
+                $result[] = [
+                    'title' => $title,
+                    'phase' => $phase,
+                    'float' => $floatPartValue,
+                    'dmarket_price_usd' => $target['Price']['Amount'] ?? null,
+                    'best_buff_price_cny' => $buffPrice,
+                ];
             }
 
-            $range = $this->getPaintwearRange($floatPartValue);
-            $buffData = $buff->getSellOrders($watchItem->item_id, $range['min'], $range['max']);
+            return response()->json($result);
+        }
 
-            $orders = $buffData['data']['items'] ?? [];
-            if ($phase) {
-                $orders = array_values(array_filter($orders, fn ($o) => ($o['asset_info']['info']['phase_data']['name'] ?? null) === $phase));
-            }
+        $watchItems = UserWatchlistItem::where('active', true)->get();
 
-            if ($orders) {
-                usort($orders, fn ($a, $b) => floatval($a['price']) <=> floatval($b['price']));
-                $buffPrice = $orders[0]['price'];
-            } else {
-                $buffPrice = null;
-            }
+        foreach ($watchItems as $item) {
+            $dmData = $dmarket->getMarketItems([
+                'gameId' => 'a8db',
+                'title' => $item->title,
+                'currency' => 'USD',
+                'limit' => 1,
+                'orderBy' => 'price',
+                'orderDir' => 'asc',
+            ]);
+
+            $obj = $dmData['objects'][0] ?? null;
+
+            $dmPrice = $obj['price']['USD'] ?? null;
+            $phase = $obj['extra']['phase'] ?? null;
+            $float = $obj['extra']['floatPartValue'] ?? null;
 
             $result[] = [
-                'title' => $title,
+                'title' => $item->title,
                 'phase' => $phase,
-                'float' => $floatPartValue,
-                'dmarket_price_usd' => $target['Price']['Amount'] ?? null,
-                'best_buff_price_cny' => $buffPrice,
+                'float' => $float,
+                'dmarket_price_usd' => $dmPrice,
+                'buff_target_price_usd' => $item->max_price_usd ? $item->max_price_usd / 100 : null,
             ];
         }
 

--- a/app/Services/DMarketService.php
+++ b/app/Services/DMarketService.php
@@ -116,6 +116,25 @@ class DMarketService
         return $this->sendRequest('POST', '/marketplace-api/v1/user-targets/create', [], $targetData);
     }
 
+    public function getMarketItems(array $params): ?array
+    {
+        try {
+            $url = $this->buildUrl('/exchange/v1/market/items');
+            $response = Http::acceptJson()->get($url, $params);
+
+            if ($response->failed()) {
+                Log::error("DMarket market items error [{$url}]: {$response->status()}", [
+                    'body' => $response->body(),
+                ]);
+            }
+
+            return $response->json();
+        } catch (\Throwable $e) {
+            Log::error('DMarket market items request failed', ['exception' => $e->getMessage()]);
+            return null;
+        }
+    }
+
     public function compareWithBuff(array $filters = []): ?array
     {
         $dmarketItems = $this->getMarketTargets($filters['gameId'] ?? 'a8db', $filters['title'] ?? '');

--- a/resources/js/pages/WatchlistOrders.vue
+++ b/resources/js/pages/WatchlistOrders.vue
@@ -157,7 +157,7 @@ const submit = async () => {
                     <th class="border px-2 py-1">Phase</th>
                     <th class="border px-2 py-1">Float</th>
                     <th class="border px-2 py-1">DMarket $</th>
-                    <th class="border px-2 py-1">Buff ¥</th>
+                    <th class="border px-2 py-1">Buff Target $</th>
                 </tr>
             </thead>
             <tbody>
@@ -166,7 +166,7 @@ const submit = async () => {
                     <td class="border px-2 py-1">{{ c.phase || '/' }}</td>
                     <td class="border px-2 py-1">{{ c.float || '/' }}</td>
                     <td class="border px-2 py-1 text-right">{{ c.dmarket_price_usd ?? '-' }}</td>
-                    <td class="border px-2 py-1 text-right">{{ c.best_buff_price_cny ?? '-' }}</td>
+                    <td class="border px-2 py-1 text-right">{{ c.buff_target_price_usd ?? c.best_buff_price_cny ?? '-' }}</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add DMarketService::getMarketItems for `/exchange/v1/market/items`
- extend comparison endpoint to use watchlist items when no active targets
- adjust WatchlistOrders table headers to show buff target price

## Testing
- `composer test` *(fails: command not found)*
- `npm run lint` *(fails: missing eslint-config-prettier)*

------
https://chatgpt.com/codex/tasks/task_b_684d9159e9788326a6e9bcd9523f786c